### PR TITLE
Put backticks around link, so you can add spaces

### DIFF
--- a/RestructuredText.sublime-completions
+++ b/RestructuredText.sublime-completions
@@ -25,7 +25,7 @@
 
 		{ "trigger": "table", "contents": "${1/./=/g}\n${1:heading}\n${1/./=/g}\n${2:row}\n${3:row}\n${4:row}\n${1/./=/g}" },
 
-		{ "trigger": "link", "contents": "${1:link_variable_name}_ $0\n\n.. _${1}: ${2:http://}"},
+		{ "trigger": "link", "contents": "`${1:link_variable_name}`_ $0\n\n.. _${1}: ${2:http://}"},
 		{ "trigger": "linki", "contents": "`${1:link_variable_name} <${2:http://}>`_ $0"},
         { "trigger": "fn, cite", "contents": "[${2:#}]_ $0\n\n.. [${2}] ${1:footnote}" },
 


### PR DESCRIPTION
This keeps links consistently always using `link`_ syntax, and allows people to use spaces in their link names.
