### PR TITLE
Update Default (Linux).sublime-keymap

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -115,25 +115,25 @@
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
           ]
     },
-     { "keys": ["ctrl+down"], "command": "headline_move",
+     { "keys": ["alt+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+down"], "command": "headline_move",
+    { "keys": ["ctrl+alt+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+up"], "command": "headline_move",
+    { "keys": ["alt+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+up"], "command": "headline_move",
+    { "keys": ["ctrl+alt+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }


### PR DESCRIPTION
Update Default Linux keymap to remove conflict with Sublime Default `ctrl+shift+up` & `ctrl+shift+down` keys - used for moving text blocks/selections around.
