### PR TITLE
StrongEmphasisCommand is named wrong as it's referenced as 'strongemphas...

### DIFF
--- a/simpleformat.py
+++ b/simpleformat.py
@@ -14,7 +14,7 @@ class SurroundCommand(sublime_plugin.TextCommand):
             self.view.replace(edit, sel, replacement)
 
 
-class StrongEmphasisCommand(SurroundCommand):
+class StrongemphasisCommand(SurroundCommand):
     surround = "**"
 
 


### PR DESCRIPTION
...is' in the keymaps. Renamed to StrongemphasisCommand
