### PR TITLE
Keymap conflicts (ctrl+up/ctrl+down -> alt+up/alt+down)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -115,31 +115,28 @@
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
           ]
     },
-     { "keys": ["ctrl+down"], "command": "headline_move",
+     { "keys": ["alt+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+down"], "command": "headline_move",
+    { "keys": ["alt+shift+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+up"], "command": "headline_move",
+    { "keys": ["alt+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+up"], "command": "headline_move",
+    { "keys": ["alt+shift+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     }
-
-
-
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -108,7 +108,8 @@
                "operand": ".*\\[\\d+\\]_" }
 
         ]
-    }, {"keys": ["ctrl+shift+r"], "command": "render_rst", "context":
+    },
+    {"keys": ["ctrl+shift+r"], "command": "render_rst", "context":
           [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
           ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -115,31 +115,28 @@
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
           ]
     },
-     { "keys": ["ctrl+down"], "command": "headline_move",
+     { "keys": ["alt+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+down"], "command": "headline_move",
+    { "keys": ["alt+shift+down"], "command": "headline_move",
       "args": {"forward": true, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+up"], "command": "headline_move",
+    { "keys": ["alt+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": false}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     },
-    { "keys": ["ctrl+shift+up"], "command": "headline_move",
+    { "keys": ["alt+shift+up"], "command": "headline_move",
       "args": {"forward": false, "same_or_high": true}, "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.restructuredtext" }
         ]
     }
-
-
-
 ]

--- a/README.rst
+++ b/README.rst
@@ -350,12 +350,11 @@ Navigation
 ++++++++++
 
 Also, it's possible to jump between headers.
-``ctrl+down`` and ``ctrl+up`` (``alt+down`` and ``alt+up`` in Mac) move the
-cursor position to the closer next or previous header respectively.
+``alt+down`` and ``alt+up`` move the cursor position to the closer next or
+previous header respectively.
 
-``ctrl+shift+down`` and ``ctrl+shift+up`` (``alt+shift+down`` and ``alt+shift+up``
-in Mac) to the same, but only between headers with the same or higher level
-(i.e. ignore childrens)
+``alt+shift+down`` and ``alt+shift+up`` to the same, but only between headers
+with the same or higher level (i.e. ignore childrens)
 
 The header level is detected automatically.
 


### PR DESCRIPTION
Issue #54 also showed the problem exists in linux (I only had fixed it in OS X) and most likely it's an issue in Windows as well. This fixes this and updates the README file.
