### PR TITLE
Indented titles

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -151,8 +151,10 @@ class RstHeaderTree(object):
 
     @classmethod
     def make_header(cls, title, adornment, force_overline=False):
-        title_lenght = len(title)
-        strike = adornment[0] * title_lenght
+        title = title.rstrip()
+        title_lenght = len(title.lstrip())
+        indent_lenght = len(title) - title_lenght
+        strike = adornment[0] * (title_lenght + indent_lenght * 2)
         if force_overline or len(adornment) == 2:
             result = strike + '\n' + title + '\n' + strike + '\n'
         else:


### PR DESCRIPTION
This adds support for indented headers:

```
**
  Hello
***<TAB>
```

produces:

```
*********
  Hello
*********
```

(Also removes `encoding()`, taken from #53, which should be the proper way of getting the length of the title)
