### PR TITLE
add Korean support in SmartHeaderCommand

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -164,6 +164,7 @@ class RstHeaderTree(object):
         title_lenght = len(title.lstrip())
         indent_lenght = len(title) - title_lenght
         title_lenght += len(''.join(re.compile(u"[\u4e00-\u9fa5]+").findall(title)))
+        title_lenght += len(''.join(re.compile(u"[\uac00-\ud7af]+").findall(title)))
         strike = adornment[0] * (title_lenght + indent_lenght * 2)
         if force_overline or len(adornment) == 2:
             result = strike + '\n' + title + '\n' + strike + '\n'


### PR DESCRIPTION
add Korean support in SmartHeaderCommand.
It is almost identical code with  [8ec8e46](https://github.com/mgaitan/sublime-rst-completion/commit/8ec8e46635ec7379a9505d56a6b85540418cff5d)
I've just added Korean unicode range.