### PR TITLE
fix(headers.py):  fix bug in handling of [shift+tab]

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -292,9 +292,11 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
             # `unindent` when user is editing reSTructuredText), this ELSE block
             # must check a few more variables.  Namely:  3 things govern normal
             # [shift+tab] behavior:
+            #
             # A.  If multiple lines selected (text contains "\n"), run `unindent` command.
             # B.  If text before cursor is zero or more tabs or spaces, run `unindent` command.
             # C.  If `settings.shift_tab_unindent` == True, then run `unindent` command.
+            #
             # Otherwise, when user is editing reSTructuredText files, tab gets
             # inserted when it should be running `unindent` command.  These rules
             # are shown in the default Sublime Text [shift+tab] key bindings.
@@ -320,7 +322,7 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
                 return
             else:
                 left_of_cursor_text = line_text[0:diff]
-                if diff == 0 or re.match(r'^[\t ]+$', left_of_cursor_text):
+                if re.match(r'^[\t ]+$', left_of_cursor_text):
                     # Only tabs or spaces to the left of cursor.
                     self.view.run_command('unindent')
                     return

--- a/headers.py
+++ b/headers.py
@@ -334,7 +334,7 @@ class SmartFoldingCommand(sublime_plugin.TextCommand):
                 self.view.run_command('unindent')
             else:
                 # Finally, here it is correct to insert a '\t'
-                for r in self.view.sel():
+                for r in reversed(self.view.sel()):
                     self.view.insert(edit, r.a, '\t')
                     self.view.show(r)
 


### PR DESCRIPTION
The `sublime-rst-completion` Package binds [shift+tab] to the headers::SmartFoldingCommand().  However, it was failing to honor the conditions when it should have been running the `unindent` command instead of inserting a '\t' character.  These rules are visible in the Sublime Text default Key Bindings, where the below rules (top to bottom) are processed in the Key Bindings bottom to top:

- '\n' appears in selected text (i.e. multiple lines are selected),
- text before cursor is zero-or-more tabs or spaces (see note below),
- settings.shift_tab_unindent == True

If any of the above conditions is true, then `unindent` command must be run. Otherwise, it appropriate to insert a '\t' character as a response to [shift+tab]. (This assumes the user has not overridden the default [shift+tab] Key Bindings.)

Note:  It is verified that Sublime Text runs the `unindent` command, even when the cursor is at the beginning of the line and a non-blank character is immediately to the right of it.  No change occurs, but the command log shows it was run.  The code in this PR aligns with that behavior.  If the user needs to insert a '\t' character, he/she can just hit the normal [Tab] key (without the `shift` modifier).

This PR fixes the erroneous behavior of the "smart_folding" comand.